### PR TITLE
Update checkbox_with_label.test.tsx

### DIFF
--- a/examples/typescript/__tests__/checkbox_with_label.test.tsx
+++ b/examples/typescript/__tests__/checkbox_with_label.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import * as TestUtils from 'react-addons-test-utils';
+import * as TestUtils from 'react-dom/test-utils';
 
 const CheckboxWithLabel = require('../CheckboxWithLabel');
 


### PR DESCRIPTION
ReactTestUtils has been moved to 'react-dom/test-utils'

**Summary**

Update references of Test Utils.

**Test plan**

if run jest test, the warning below will not appear.
`Warning: ReactTestUtils has been moved to react-dom/test-utils. Update references to remove this warning.`
